### PR TITLE
Refine routing, middleware, and idempotency handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # Global build args (visible to all stages)
 ############################
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.22.6
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG DATE=unknown
@@ -11,7 +11,9 @@ ARG DATE=unknown
 ############################
 # Build stage
 ############################
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}@sha256:1cf6c45ba39db9fd6db16922041d074a63c935556a05c5ccb62d181034df7f02 AS build
+# Pin the Go toolchain by tag so `GO_VERSION` stays configurable without
+# breaking the FROM line. Distroless stays digest-pinned for supply-chain safety.
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS build
 WORKDIR /src
 
 # Re-import global args into this stage's scope
@@ -19,8 +21,10 @@ ARG VERSION
 ARG COMMIT
 ARG DATE
 
+# The project uses the pure-Go SQLite driver, so CGO can stay disabled to
+# produce a portable static binary.
 ENV GOTOOLCHAIN=auto \
-    CGO_ENABLED=1
+    CGO_ENABLED=0
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -59,7 +63,7 @@ LABEL org.opencontainers.image.title="go-chat-backend" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.revision="${COMMIT}" \
       org.opencontainers.image.created="${DATE}" \
-      org.opencontainers.image.source="https://github.com/your/repo" \
+      org.opencontainers.image.source="https://github.com/tbourn/go-chat-backend" \
       org.opencontainers.image.licenses="MIT"
 
 USER 65532:65532

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -170,18 +170,8 @@ func main() {
 	}
 
 	// ---------- Router & middleware ----------
-	r := gin.New()
-	r.Use(gzip.Gzip(gzip.DefaultCompression))
-
-	// Simple user identity stub
-	r.Use(func(c *gin.Context) {
-		uid := strings.TrimSpace(c.GetHeader("X-User-ID"))
-		if uid == "" {
-			uid = "demo-user"
-		}
-		c.Set("userID", uid)
-		c.Next()
-	})
+        r := gin.New()
+        r.Use(gzip.Gzip(gzip.DefaultCompression))
 
 	// Wire routes (otel, metrics, cors, security, api, etc. are set inside)
 	httpapi.RegisterRoutes(r, db, idx, cfg)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,9 @@ services:
     ports:
       - "${PORT:-8080}:8080"
 
-    volumes:
+      # Persist application state (SQLite) and make Markdown sources editable
+      # without rebuilding the container. The app filesystem stays read-only.
+      volumes:
       - type: bind
         source: ./.data
         target: /data

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tbourn/go-chat-backend
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.22
 
 require (
 	github.com/gin-contrib/cors v1.7.6

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,10 +43,11 @@ type Config struct {
 	GinMode           string        // debug|release|test
 
 	// Logging / Docs
-	LogLevel       string // debug|info|warn|error|fatal|panic
-	LogPretty      bool   // pretty console logs in dev
-	SwaggerEnabled bool   // enable Swagger UI route
-	APIBasePath    string // base path for API routes
+	LogLevel       string   // debug|info|warn|error|fatal|panic
+	LogPretty      bool     // pretty console logs in dev
+	RedactHeaders  []string // headers to mask in access logs
+	SwaggerEnabled bool     // enable Swagger UI route
+	APIBasePath    string   // base path for API routes
 
 	// App
 	DBPath    string  // SQLite path
@@ -94,6 +95,7 @@ func Load() (Config, error) {
 		// Logging / Docs
 		LogLevel:       strings.ToLower(getenv("LOG_LEVEL", "info")),
 		LogPretty:      getbool("LOG_PRETTY", false),
+		RedactHeaders:  splitCSV(getenv("LOG_REDACT_HEADERS", "Authorization,X-API-Key")),
 		SwaggerEnabled: getbool("SWAGGER_ENABLED", false),
 		APIBasePath:    normalizeBasePath(getenv("API_BASE_PATH", "/api/v1")),
 

--- a/internal/domain/idempotency.go
+++ b/internal/domain/idempotency.go
@@ -10,10 +10,13 @@ import "time"
 // operations by returning the originally produced response without re-executing
 // side effects.
 type Idempotency struct {
-	ID        string    `gorm:"type:TEXT NOT NULL;primaryKey"`
-	UserID    string    `gorm:"type:TEXT NOT NULL;uniqueIndex:ux_user_chat_key,priority:1"`
-	ChatID    string    `gorm:"type:TEXT NOT NULL;uniqueIndex:ux_user_chat_key,priority:2"`
-	Key       string    `gorm:"type:TEXT NOT NULL;uniqueIndex:ux_user_chat_key,priority:3"`
+        ID        string    `gorm:"type:TEXT NOT NULL;primaryKey"`
+        // Priority enforces a deterministic composite unique index ordering on
+        // SQLite so lookups can use the (user_id, chat_id, key) tuple without
+        // additional columns.
+        UserID    string    `gorm:"type:TEXT NOT NULL;uniqueIndex:ux_user_chat_key,priority:1"`
+        ChatID    string    `gorm:"type:TEXT NOT NULL;uniqueIndex:ux_user_chat_key,priority:2"`
+        Key       string    `gorm:"type:TEXT NOT NULL;uniqueIndex:ux_user_chat_key,priority:3"`
 	MessageID string    `gorm:"type:TEXT NOT NULL"`
 	Status    int       `gorm:"type:INTEGER NOT NULL"`
 	CreatedAt time.Time `gorm:"type:DATETIME NOT NULL;autoCreateTime"`

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -19,6 +19,9 @@ import (
 //   - Title: human-readable chat title (auto-generated if not provided).
 //   - CreatedAt / UpdatedAt: timestamps managed by GORM.
 //   - DeletedAt: soft deletion marker (retains row for audit/history).
+//
+// We intentionally do not embed gorm.Model because the default integer ID and
+// timestamp fields do not match our UUID/string key strategy.
 type Chat struct {
 	ID        string         `json:"id"        gorm:"type:char(36);primaryKey"`
 	UserID    string         `json:"user_id"   gorm:"type:varchar(64);not null;index:idx_user_chats"`
@@ -44,6 +47,9 @@ func (Chat) TableName() string { return "chats" }
 //   - CreatedAt / UpdatedAt: timestamps managed by GORM.
 //   - DeletedAt: soft deletion marker.
 //   - Chat: FK association, ensures cascade delete/update.
+//
+// We intentionally avoid gorm.Model here for the same reason as Chat: the
+// built-in uint primary key does not align with UUID identifiers.
 type Message struct {
 	ID        string         `json:"id"        gorm:"type:char(36);primaryKey"`
 	ChatID    string         `json:"chat_id"   gorm:"type:char(36);not null;index:idx_chat_msgs,priority:1"`
@@ -73,6 +79,8 @@ func (Message) TableName() string { return "messages" }
 //   - CreatedAt / UpdatedAt: timestamps managed by GORM.
 //   - DeletedAt: soft deletion marker.
 //   - Message: FK association, ensures cascade delete/update.
+//
+// Feedback keeps string UUIDs as primary keys, so we avoid gorm.Model here as well.
 type Feedback struct {
 	ID        string         `json:"id"         gorm:"type:char(36);primaryKey"`
 	MessageID string         `json:"message_id" gorm:"type:char(36);not null;index;uniqueIndex:ux_feedback_message_user"`

--- a/internal/http/ctxutil/pagination.go
+++ b/internal/http/ctxutil/pagination.go
@@ -1,0 +1,46 @@
+package ctxutil
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PaginationConfig defines sane defaults and limits for paginated endpoints.
+type PaginationConfig struct {
+	DefaultPage     int
+	DefaultPageSize int
+	MaxPageSize     int
+}
+
+// PaginationParams reads page/page_size query params, applies defaults and
+// bounds, and returns the sanitized values.
+func PaginationParams(c *gin.Context, cfg PaginationConfig) (page, pageSize int) {
+	if cfg.DefaultPage <= 0 {
+		cfg.DefaultPage = 1
+	}
+	if cfg.DefaultPageSize <= 0 {
+		cfg.DefaultPageSize = 20
+	}
+	if cfg.MaxPageSize <= 0 {
+		cfg.MaxPageSize = 100
+	}
+	page = cfg.DefaultPage
+	pageSize = cfg.DefaultPageSize
+	if c != nil {
+		if p := c.Query("page"); p != "" {
+			if v, err := strconv.Atoi(p); err == nil && v > 0 {
+				page = v
+			}
+		}
+		if ps := c.Query("page_size"); ps != "" {
+			if v, err := strconv.Atoi(ps); err == nil && v > 0 {
+				pageSize = v
+			}
+		}
+	}
+	if pageSize > cfg.MaxPageSize {
+		pageSize = cfg.MaxPageSize
+	}
+	return
+}

--- a/internal/http/ctxutil/user.go
+++ b/internal/http/ctxutil/user.go
@@ -1,0 +1,20 @@
+package ctxutil
+
+import "github.com/gin-gonic/gin"
+
+// UserID returns the caller identity stored on the Gin context. Upstream
+// authentication middleware is expected to stash it under the "userID" key.
+//
+// When no identity is available (e.g. in local development), the function
+// falls back to the demo user that our middleware injects.
+func UserID(c *gin.Context) string {
+	if c == nil {
+		return "demo-user"
+	}
+	if v, ok := c.Get("userID"); ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return "demo-user"
+}

--- a/internal/http/handlers/chat_handler.go
+++ b/internal/http/handlers/chat_handler.go
@@ -11,18 +11,20 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/tbourn/go-chat-backend/internal/domain"
+	"github.com/tbourn/go-chat-backend/internal/http/ctxutil"
 	"github.com/tbourn/go-chat-backend/internal/repo"
 	"github.com/tbourn/go-chat-backend/internal/services"
-	"github.com/tbourn/go-chat-backend/internal/utils"
 )
 
 //
@@ -64,6 +66,14 @@ type FeedbackService interface {
 	Leave(ctx context.Context, userID, messageID string, value int) error
 }
 
+// IdempotencyService handles lookup/recording of idempotent request results.
+// It is injected so handlers remain agnostic of the persistence details.
+type IdempotencyService interface {
+	Exists(ctx context.Context, userID, chatID, key string, now time.Time) (bool, error)
+	Replay(ctx context.Context, userID, chatID, key string, now time.Time) (*domain.Message, bool, error)
+	Record(ctx context.Context, userID, chatID, key string, messageID string, status int) error
+}
+
 //
 // Handler wiring
 //
@@ -75,28 +85,12 @@ type Handlers struct {
 	chatSvc ChatService
 	msgSvc  MessageService
 	fbSvc   FeedbackService
+	idemSvc IdempotencyService
 }
 
 // New constructs and returns a Handlers instance bound to the given services.
-func New(chatSvc ChatService, msgSvc MessageService, fbSvc FeedbackService) *Handlers {
-	return &Handlers{chatSvc: chatSvc, msgSvc: msgSvc, fbSvc: fbSvc}
-}
-
-// userID extracts the authenticated user id from Gin context (set by upstream
-// middleware). If absent, it falls back to "X-User-ID" header (tests use it),
-// and finally to "demo-user". It never touches c.Request if it's nil.
-func userID(c *gin.Context) string {
-	if v, ok := c.Get("userID"); ok {
-		if s, ok := v.(string); ok && s != "" {
-			return s
-		}
-	}
-	if c != nil && c.Request != nil {
-		if h := strings.TrimSpace(c.GetHeader("X-User-ID")); h != "" {
-			return h
-		}
-	}
-	return "demo-user"
+func New(chatSvc ChatService, msgSvc MessageService, fbSvc FeedbackService, idemSvc IdempotencyService) *Handlers {
+	return &Handlers{chatSvc: chatSvc, msgSvc: msgSvc, fbSvc: fbSvc, idemSvc: idemSvc}
 }
 
 //
@@ -134,28 +128,6 @@ type ListChatsResponse struct {
 // Helpers
 //
 
-// clampPagination parses and bounds page and page_size query params to sane
-// defaults and limits, returning (page, pageSize).
-func clampPagination(c *gin.Context) (page, pageSize int) {
-	const (
-		defaultPage     = 1
-		defaultPageSize = 20
-		maxPageSize     = 100
-	)
-	page = utils.AtoiDefault(c.Query("page"), defaultPage)
-	if page < 1 {
-		page = 1
-	}
-	pageSize = utils.AtoiDefault(c.Query("page_size"), defaultPageSize)
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	if pageSize > maxPageSize {
-		pageSize = maxPageSize
-	}
-	return
-}
-
 //
 // Handlers
 //
@@ -183,7 +155,7 @@ func (h *Handlers) CreateChat(c *gin.Context) {
 	}
 	title := strings.TrimSpace(req.Title)
 
-	ch, err := h.chatSvc.Create(c.Request.Context(), userID(c), title)
+	ch, err := h.chatSvc.Create(c.Request.Context(), ctxutil.UserID(c), title)
 	if err != nil {
 		fail(c, http.StatusInternalServerError, ErrCodeCreateFailed, err.Error())
 		return
@@ -212,8 +184,12 @@ func (h *Handlers) CreateChat(c *gin.Context) {
 // @Router      /chats [get]
 func (h *Handlers) ListChats(c *gin.Context) {
 	ctx := c.Request.Context()
-	uid := userID(c)
-	page, pageSize := clampPagination(c)
+	uid := ctxutil.UserID(c)
+	page, pageSize := ctxutil.PaginationParams(c, ctxutil.PaginationConfig{
+		DefaultPage:     1,
+		DefaultPageSize: 20,
+		MaxPageSize:     100,
+	})
 
 	// ETag pre-check (best effort).
 	var db *gorm.DB
@@ -273,7 +249,7 @@ func (h *Handlers) ListChats(c *gin.Context) {
 // @Failure     400  {object} handlers.ErrorResponse "Bad request"
 // @Failure     404  {object} handlers.ErrorResponse "Chat not found"
 // @Failure     500  {object} handlers.ErrorResponse "Internal error"
-// @Router      /chats/{id}/title [put]
+// @Router      /chats/{id} [patch]
 func (h *Handlers) UpdateChatTitle(c *gin.Context) {
 	chatID := c.Param("id")
 	if _, err := uuid.Parse(chatID); err != nil {
@@ -287,8 +263,12 @@ func (h *Handlers) UpdateChatTitle(c *gin.Context) {
 		return
 	}
 
-	if err := h.chatSvc.UpdateTitle(c.Request.Context(), userID(c), chatID, req.Title); err != nil {
-		fail(c, http.StatusNotFound, ErrCodeNotFound, "chat not found")
+	if err := h.chatSvc.UpdateTitle(c.Request.Context(), ctxutil.UserID(c), chatID, req.Title); err != nil {
+		if errors.Is(err, services.ErrChatNotFound) {
+			fail(c, http.StatusNotFound, ErrCodeNotFound, "chat not found")
+			return
+		}
+		fail(c, http.StatusInternalServerError, ErrCodeInternal, err.Error())
 		return
 	}
 

--- a/internal/http/handlers/chat_handler_test.go
+++ b/internal/http/handlers/chat_handler_test.go
@@ -90,6 +90,33 @@ func (stubFBSvcChat) Leave(ctx context.Context, userID, messageID string, value 
 	return nil
 }
 
+type stubIdemSvc struct {
+	exists func(context.Context, string, string, string, time.Time) (bool, error)
+	replay func(context.Context, string, string, string, time.Time) (*domain.Message, bool, error)
+	record func(context.Context, string, string, string, string, int) error
+}
+
+func (s stubIdemSvc) Exists(ctx context.Context, user, chat, key string, now time.Time) (bool, error) {
+	if s.exists != nil {
+		return s.exists(ctx, user, chat, key, now)
+	}
+	return false, nil
+}
+
+func (s stubIdemSvc) Replay(ctx context.Context, user, chat, key string, now time.Time) (*domain.Message, bool, error) {
+	if s.replay != nil {
+		return s.replay(ctx, user, chat, key, now)
+	}
+	return nil, false, nil
+}
+
+func (s stubIdemSvc) Record(ctx context.Context, user, chat, key, messageID string, status int) error {
+	if s.record != nil {
+		return s.record(ctx, user, chat, key, messageID, status)
+	}
+	return nil
+}
+
 // Flexible chat service stub for UpdateTitle tests
 type stubChatSvcChat struct {
 	create    func(context.Context, string, string) (*domain.Chat, error)
@@ -126,51 +153,6 @@ func (s stubChatSvcChat) UpdateTitle(ctx context.Context, u, id, t string) error
 	return nil
 }
 
-// ---------- helpers-only tests ----------
-
-func Test_userID_and_clampPagination(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	// userID helper
-	rc := gin.CreateTestContextOnly(httptest.NewRecorder(), gin.New())
-	if got := userID(rc); got != "demo-user" {
-		t.Fatalf("fallback userID = %q", got)
-	}
-	rc.Set("userID", "u1")
-	if got := userID(rc); got != "u1" {
-		t.Fatalf("ctx userID = %q", got)
-	}
-	rc.Set("userID", 123) // wrong type → fallback
-	if got := userID(rc); got != "demo-user" {
-		t.Fatalf("wrong-type fallback userID = %q", got)
-	}
-
-	// header fallback
-	cH, _ := gin.CreateTestContext(httptest.NewRecorder())
-	reqH := httptest.NewRequest("GET", "/", nil)
-	reqH.Header.Set("X-User-ID", "u-123")
-	cH.Request = reqH
-	if got := userID(cH); got != "u-123" {
-		t.Fatalf("header fallback userID = %q", got)
-	}
-
-	// clampPagination bounds
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	req := httptest.NewRequest("GET", "/?page=-5&page_size=9999", nil)
-	c.Request = req
-	p, ps := clampPagination(c)
-	if p != 1 || ps != 100 {
-		t.Fatalf("clamp bounds got p=%d ps=%d", p, ps)
-	}
-	c, _ = gin.CreateTestContext(httptest.NewRecorder())
-	req = httptest.NewRequest("GET", "/?page=&page_size=0", nil)
-	c.Request = req
-	p, ps = clampPagination(c)
-	if p != 1 || ps != 1 {
-		t.Fatalf("clamp defaults got p=%d ps=%d", p, ps)
-	}
-}
-
 // ---------- CreateChat ----------
 
 func TestCreateChat_BadJSON_Success_Internal(t *testing.T) {
@@ -178,7 +160,7 @@ func TestCreateChat_BadJSON_Success_Internal(t *testing.T) {
 
 	// Bad JSON -> 400
 	{
-		h := New(stubChatSvcChat{}, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(stubChatSvcChat{}, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
 		r.POST("/chats", h.CreateChat)
 
@@ -195,7 +177,7 @@ func TestCreateChat_BadJSON_Success_Internal(t *testing.T) {
 	{
 		db := newChatDB(t)
 		svc := services.NewChatService(db, testChatRepo{})
-		h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
 		r.POST("/chats", h.CreateChat)
 
@@ -222,7 +204,7 @@ func TestCreateChat_BadJSON_Success_Internal(t *testing.T) {
 				return nil, gorm.ErrInvalidField
 			},
 		}
-		h := New(errSvc, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(errSvc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
 		r.POST("/chats", h.CreateChat)
 
@@ -243,7 +225,7 @@ func TestListChats_ETag304_and_SuccessPage(t *testing.T) {
 	db := newChatDB(t)
 	repoShim := testChatRepo{}
 	svc := services.NewChatService(db, repoShim)
-	h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{})
+	h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 
 	// Seed chats for user u1
 	now := time.Now().UTC()
@@ -310,12 +292,12 @@ func TestUpdateChatTitle_UUID_Binding_Success_NotFound(t *testing.T) {
 
 	// bad UUID
 	{
-		h := New(stubChatSvcChat{}, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(stubChatSvcChat{}, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
-		r.PUT("/chats/:id/title", h.UpdateChatTitle)
+		r.PATCH("/chats/:id", h.UpdateChatTitle)
 
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPut, "/chats/not-uuid/title", bytes.NewBufferString(`{"title":"x"}`))
+		req := httptest.NewRequest(http.MethodPatch, "/chats/not-uuid", bytes.NewBufferString(`{"title":"x"}`))
 		req.Header.Set("X-User-ID", "u1")
 		r.ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -325,12 +307,12 @@ func TestUpdateChatTitle_UUID_Binding_Success_NotFound(t *testing.T) {
 
 	// empty title -> 400
 	{
-		h := New(stubChatSvcChat{}, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(stubChatSvcChat{}, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
-		r.PUT("/chats/:id/title", h.UpdateChatTitle)
+		r.PATCH("/chats/:id", h.UpdateChatTitle)
 
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPut, "/chats/"+uuid.NewString()+"/title", bytes.NewBufferString(`{"title":"   "}`))
+		req := httptest.NewRequest(http.MethodPatch, "/chats/"+uuid.NewString(), bytes.NewBufferString(`{"title":"   "}`))
 		req.Header.Set("X-User-ID", "u1")
 		r.ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -347,13 +329,13 @@ func TestUpdateChatTitle_UUID_Binding_Success_NotFound(t *testing.T) {
 				return nil
 			},
 		}
-		h := New(okSvc, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(okSvc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
-		r.PUT("/chats/:id/title", h.UpdateChatTitle)
+		r.PATCH("/chats/:id", h.UpdateChatTitle)
 
 		chatID := uuid.NewString()
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPut, "/chats/"+chatID+"/title", bytes.NewBufferString(`{"title":"New Name"}`))
+		req := httptest.NewRequest(http.MethodPatch, "/chats/"+chatID, bytes.NewBufferString(`{"title":"New Name"}`))
 		req.Header.Set("X-User-ID", "U-9")
 		r.ServeHTTP(w, req)
 		if w.Code != http.StatusNoContent {
@@ -369,12 +351,12 @@ func TestUpdateChatTitle_UUID_Binding_Success_NotFound(t *testing.T) {
 		errSvc := stubChatSvcChat{
 			updateTit: func(context.Context, string, string, string) error { return gorm.ErrRecordNotFound },
 		}
-		h := New(errSvc, stubMsgSvcChat{}, stubFBSvcChat{})
+		h := New(errSvc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 		r := gin.New()
-		r.PUT("/chats/:id/title", h.UpdateChatTitle)
+		r.PATCH("/chats/:id", h.UpdateChatTitle)
 
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPut, "/chats/"+uuid.NewString()+"/title", bytes.NewBufferString(`{"title":"X"}`))
+		req := httptest.NewRequest(http.MethodPatch, "/chats/"+uuid.NewString(), bytes.NewBufferString(`{"title":"X"}`))
 		req.Header.Set("X-User-ID", "u1")
 		r.ServeHTTP(w, req)
 		if w.Code != http.StatusNotFound {
@@ -392,7 +374,7 @@ func TestListChats_SkipETagPrecheck_And_ListError(t *testing.T) {
 			return nil, 0, gorm.ErrInvalidField
 		},
 	}
-	h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{})
+	h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 
 	r := gin.New()
 	r.GET("/chats", h.ListChats)
@@ -415,7 +397,7 @@ func TestListChats_EmptyState_SetsETag_WithZeroTS(t *testing.T) {
 	// Real service with migrated DB, but no chats for this user → count=0, maxTS=nil.
 	db := newChatDB(t)
 	svc := services.NewChatService(db, testChatRepo{})
-	h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{})
+	h := New(svc, stubMsgSvcChat{}, stubFBSvcChat{}, stubIdemSvc{})
 
 	r := gin.New()
 	r.GET("/chats", h.ListChats)

--- a/internal/http/handlers/feedback_handler.go
+++ b/internal/http/handlers/feedback_handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/tbourn/go-chat-backend/internal/http/ctxutil"
 	"github.com/tbourn/go-chat-backend/internal/services"
 )
 
@@ -57,8 +58,8 @@ func (h *Handlers) LeaveFeedback(c *gin.Context) {
 		return
 	}
 
-	// Pull user from context → header → demo fallback (implemented in chat_handler.go)
-	uid := userID(c)
+	// Pull user from context → header → demo fallback.
+	uid := ctxutil.UserID(c)
 	messageID := c.Param("id")
 
 	if err := h.fbSvc.Leave(c.Request.Context(), uid, messageID, req.Value); err != nil {

--- a/internal/http/handlers/feedback_handler_test.go
+++ b/internal/http/handlers/feedback_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -54,6 +55,18 @@ func (s stubFBSvc) Leave(ctx context.Context, userID, messageID string, value in
 	return s.fn(ctx, userID, messageID, value)
 }
 
+type stubIdemSvc struct{}
+
+func (stubIdemSvc) Exists(context.Context, string, string, string, time.Time) (bool, error) {
+	return false, nil
+}
+
+func (stubIdemSvc) Replay(context.Context, string, string, string, time.Time) (*domain.Message, bool, error) {
+	return nil, false, nil
+}
+
+func (stubIdemSvc) Record(context.Context, string, string, string, string, int) error { return nil }
+
 // ---- tests ----
 
 func TestLeaveFeedback_BindingError(t *testing.T) {
@@ -62,7 +75,7 @@ func TestLeaveFeedback_BindingError(t *testing.T) {
 		t.Fatalf("service should not be called on binding error")
 		return nil
 	}}
-	h := New(stubChatSvcFeedback{}, stubMsgSvcFeedback{}, fb)
+	h := New(stubChatSvcFeedback{}, stubMsgSvcFeedback{}, fb, stubIdemSvc{})
 
 	r := gin.New()
 	r.POST("/messages/:id/feedback", h.LeaveFeedback)
@@ -115,7 +128,7 @@ func TestLeaveFeedback_ErrorMappings(t *testing.T) {
 				}
 				return tc.err
 			}}
-			h := New(stubChatSvcFeedback{}, stubMsgSvcFeedback{}, fb)
+			h := New(stubChatSvcFeedback{}, stubMsgSvcFeedback{}, fb, stubIdemSvc{})
 
 			r := gin.New()
 			r.POST("/messages/:id/feedback", h.LeaveFeedback)
@@ -157,7 +170,7 @@ func TestLeaveFeedback_Success204(t *testing.T) {
 		got.val = value
 		return nil
 	}}
-	h := New(stubChatSvcFeedback{}, stubMsgSvcFeedback{}, fb)
+	h := New(stubChatSvcFeedback{}, stubMsgSvcFeedback{}, fb, stubIdemSvc{})
 
 	r := gin.New()
 	r.POST("/messages/:id/feedback", h.LeaveFeedback)

--- a/internal/http/handlers/message_handler.go
+++ b/internal/http/handlers/message_handler.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	zlog "github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 
 	"github.com/tbourn/go-chat-backend/internal/domain"
+	"github.com/tbourn/go-chat-backend/internal/http/ctxutil"
 	"github.com/tbourn/go-chat-backend/internal/repo"
 	"github.com/tbourn/go-chat-backend/internal/services"
-	"github.com/tbourn/go-chat-backend/internal/utils"
 )
 
 //
@@ -62,28 +63,6 @@ type ListMessagesResponse struct {
 //
 // Helpers
 //
-
-// clampMsgPagination parses page/page_size from query parameters, applies sane
-// defaults and caps, and returns the validated (page, pageSize).
-func clampMsgPagination(c *gin.Context) (page, pageSize int) {
-	const (
-		defaultPage     = 1
-		defaultPageSize = 20
-		maxPageSize     = 100
-	)
-	page = utils.AtoiDefault(c.Query("page"), defaultPage)
-	if page < 1 {
-		page = 1
-	}
-	pageSize = utils.AtoiDefault(c.Query("page_size"), defaultPageSize)
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	if pageSize > maxPageSize {
-		pageSize = maxPageSize
-	}
-	return
-}
 
 // nlCollapseRE collapses runs of 3+ newlines to two, preserving paragraphs.
 var nlCollapseRE = regexp.MustCompile(`\n{3,}`)
@@ -162,19 +141,15 @@ func (h *Handlers) PostMessage(c *gin.Context) {
 		return
 	}
 
-	currentUser := userID(c)
+	currentUser := ctxutil.UserID(c)
 
 	// Idempotency (replay path) – read validated key if present.
 	idemKey, _ := middlewareGetIdempotencyKey(c)
-	if idemKey != "" {
-		if svc, okSvc := h.msgSvc.(*services.MessageService); okSvc && svc.DB != nil {
-			if rec, err := repo.GetIdempotency(ctx, svc.DB, currentUser, chatID, idemKey, time.Now().UTC()); err == nil && rec != nil {
-				if prev, err2 := repo.GetMessage(svc.DB, rec.MessageID); err2 == nil {
-					c.Header("Idempotency-Replayed", "true")
-					ok(c, http.StatusOK, PostMessageResponse{Message: prev})
-					return
-				}
-			}
+	if idemKey != "" && h.idemSvc != nil {
+		if prev, found, err := h.idemSvc.Replay(ctx, currentUser, chatID, idemKey, time.Now().UTC()); err == nil && found {
+			c.Header("Idempotency-Replayed", "true")
+			ok(c, http.StatusOK, PostMessageResponse{Message: prev})
+			return
 		}
 	}
 
@@ -195,10 +170,9 @@ func (h *Handlers) PostMessage(c *gin.Context) {
 	}
 
 	// Idempotency (store path) – best effort.
-	if idemKey != "" {
-		if svc, ok := h.msgSvc.(*services.MessageService); ok && svc.DB != nil {
-			ttl := 24 * time.Hour
-			_, _ = repo.CreateIdempotency(ctx, svc.DB, currentUser, chatID, idemKey, m.ID, http.StatusOK, ttl)
+	if idemKey != "" && h.idemSvc != nil {
+		if err := h.idemSvc.Record(ctx, currentUser, chatID, idemKey, m.ID, http.StatusOK); err != nil {
+			zlog.Ctx(ctx).Warn().Err(err).Msg("idempotency store failed")
 		}
 	}
 
@@ -251,7 +225,11 @@ func (h *Handlers) ListMessages(c *gin.Context) {
 		}
 	}
 
-	page, pageSize := clampMsgPagination(c)
+	page, pageSize := ctxutil.PaginationParams(c, ctxutil.PaginationConfig{
+		DefaultPage:     1,
+		DefaultPageSize: 20,
+		MaxPageSize:     100,
+	})
 
 	items, total, err := h.msgSvc.ListPage(ctx, chatID, page, pageSize)
 	if err != nil {

--- a/internal/http/handlers/message_handler_test.go
+++ b/internal/http/handlers/message_handler_test.go
@@ -78,6 +78,33 @@ func (stubChatSvc) ListPage(context.Context, string, int, int) ([]domain.Chat, i
 }
 func (stubChatSvc) UpdateTitle(context.Context, string, string, string) error { return nil }
 
+type stubIdemSvc struct {
+	exists func(context.Context, string, string, string, time.Time) (bool, error)
+	replay func(context.Context, string, string, string, time.Time) (*domain.Message, bool, error)
+	record func(context.Context, string, string, string, string, int) error
+}
+
+func (s stubIdemSvc) Exists(ctx context.Context, user, chat, key string, now time.Time) (bool, error) {
+	if s.exists != nil {
+		return s.exists(ctx, user, chat, key, now)
+	}
+	return false, nil
+}
+
+func (s stubIdemSvc) Replay(ctx context.Context, user, chat, key string, now time.Time) (*domain.Message, bool, error) {
+	if s.replay != nil {
+		return s.replay(ctx, user, chat, key, now)
+	}
+	return nil, false, nil
+}
+
+func (s stubIdemSvc) Record(ctx context.Context, user, chat, key, messageID string, status int) error {
+	if s.record != nil {
+		return s.record(ctx, user, chat, key, messageID, status)
+	}
+	return nil
+}
+
 // ---------- helpers-only unit tests ----------
 
 func Test_sanitizeContent_and_clamp_and_idemKey(t *testing.T) {
@@ -91,22 +118,6 @@ func Test_sanitizeContent_and_clamp_and_idemKey(t *testing.T) {
 	// Also ensure it trims to empty
 	if sanitizeContent(" \r\n\t ") != "" {
 		t.Fatalf("sanitizeContent should trim to empty")
-	}
-
-	// clampMsgPagination:
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	req := httptest.NewRequest("GET", "/?page=-3&page_size=9999", nil)
-	c.Request = req
-	p, ps := clampMsgPagination(c)
-	if p != 1 || ps != 100 {
-		t.Fatalf("clamp: got page=%d size=%d; want 1,100", p, ps)
-	}
-	c, _ = gin.CreateTestContext(httptest.NewRecorder())
-	req = httptest.NewRequest("GET", "/?page=&page_size=0", nil)
-	c.Request = req
-	p, ps = clampMsgPagination(c)
-	if p != 1 || ps != 1 {
-		t.Fatalf("clamp defaults: got %d,%d", p, ps)
 	}
 
 	// middlewareGetIdempotencyKey
@@ -131,7 +142,7 @@ func TestPostMessage_InvalidUUID_and_Binding_and_TooLong(t *testing.T) {
 			return &domain.Message{ID: "m1", ChatID: chatID, Role: "assistant", Content: "ok"}, nil
 		},
 		list: nil,
-	}, &services.FeedbackService{DB: nil})
+	}, &services.FeedbackService{DB: nil}, stubIdemSvc{})
 
 	r.POST("/chats/:id/messages", h.PostMessage)
 
@@ -154,7 +165,7 @@ func TestPostMessage_InvalidUUID_and_Binding_and_TooLong(t *testing.T) {
 	// too long content (discoverMaxPromptRunes uses *services.MessageService)
 	db := newTestDB(t)
 	ms := &services.MessageService{DB: db, MaxPromptRunes: 5}
-	h2 := New(stubChatSvc{}, ms, &services.FeedbackService{DB: db})
+	h2 := New(stubChatSvc{}, ms, &services.FeedbackService{DB: db}, stubIdemSvc{})
 	r2 := gin.New()
 	r2.POST("/chats/:id/messages", h2.PostMessage)
 	long := "123456"
@@ -193,7 +204,8 @@ func TestPostMessage_Idempotency_Replay_and_Store(t *testing.T) {
 	}
 
 	ms := &services.MessageService{DB: db, MaxPromptRunes: 2000}
-	h := New(stubChatSvc{}, ms, &services.FeedbackService{DB: db})
+	idemSvc := services.NewIdempotencyService(db, 24*time.Hour)
+	h := New(stubChatSvc{}, ms, &services.FeedbackService{DB: db}, idemSvc)
 
 	r := gin.New()
 	r.POST("/chats/:id/messages", h.PostMessage)
@@ -270,7 +282,7 @@ func TestListMessages_UUID_And_ETag304(t *testing.T) {
 	}
 
 	ms := &services.MessageService{DB: db}
-	h := New(stubChatSvc{}, ms, &services.FeedbackService{DB: db})
+	h := New(stubChatSvc{}, ms, &services.FeedbackService{DB: db}, idemSvc)
 
 	r := gin.New()
 	r.GET("/chats/:id/messages", h.ListMessages)
@@ -321,7 +333,7 @@ func TestListMessages_Success_And_Errors(t *testing.T) {
 		},
 		answer: nil,
 	}
-	hOK := New(stubChatSvc{}, svcOK, &services.FeedbackService{DB: nil})
+	hOK := New(stubChatSvc{}, svcOK, &services.FeedbackService{DB: nil}, stubIdemSvc{})
 	r := gin.New()
 	r.GET("/chats/:id/messages", hOK.ListMessages)
 
@@ -347,7 +359,7 @@ func TestListMessages_Success_And_Errors(t *testing.T) {
 		},
 		answer: nil,
 	}
-	h404 := New(stubChatSvc{}, svc404, &services.FeedbackService{DB: nil})
+	h404 := New(stubChatSvc{}, svc404, &services.FeedbackService{DB: nil}, stubIdemSvc{})
 	r2 := gin.New()
 	r2.GET("/chats/:id/messages", h404.ListMessages)
 
@@ -365,7 +377,7 @@ func TestListMessages_Success_And_Errors(t *testing.T) {
 		},
 		answer: nil,
 	}
-	h500 := New(stubChatSvc{}, svc500, &services.FeedbackService{DB: nil})
+	h500 := New(stubChatSvc{}, svc500, &services.FeedbackService{DB: nil}, stubIdemSvc{})
 	r3 := gin.New()
 	r3.GET("/chats/:id/messages", h500.ListMessages)
 

--- a/internal/http/middleware/ratelimit.go
+++ b/internal/http/middleware/ratelimit.go
@@ -13,7 +13,8 @@
 //
 // Notes:
 //   - This limiter is process-local. For horizontally scaled deployments,
-//     prefer a distributed limiter (e.g., Redis-backed) to enforce global limits.
+//     prefer a distributed limiter (e.g., Redis-backed) to enforce global limits
+//     or offload the concern entirely to an API gateway / service mesh.
 //   - The limiter is intended for edge-level abuse control and cost protection;
 //     it is not an authorization mechanism.
 package middleware

--- a/internal/http/middleware/security.go
+++ b/internal/http/middleware/security.go
@@ -9,6 +9,9 @@
 //   - Safe defaults for APIs: no CSP here (only relevant when serving HTML)
 //   - HSTS is opt-in and only applied when the request is actually HTTPS
 //   - Header values are idempotent and inexpensive to compute per request
+//   - Shipping these headers at the app layer keeps the container self-contained
+//     for local/dev usage while still allowing upstream proxies to disable them
+//     (e.g., by terminating TLS and stripping Strict-Transport-Security).
 package middleware
 
 import (

--- a/internal/http/middleware/user_stub.go
+++ b/internal/http/middleware/user_stub.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DemoUser injects a development-friendly user identity when upstream
+// authentication is not present. It preserves any identity that was already
+// established earlier in the chain and falls back to the X-User-ID header
+// (used by tests and local tooling) before defaulting to "demo-user".
+func DemoUser() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if v, ok := c.Get("userID"); ok {
+			if s, ok := v.(string); ok && s != "" {
+				c.Next()
+				return
+			}
+		}
+		uid := strings.TrimSpace(c.GetHeader("X-User-ID"))
+		if uid == "" {
+			uid = "demo-user"
+		}
+		c.Set("userID", uid)
+		c.Next()
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -89,42 +89,39 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, idx search.Index, cfg config.Con
 	// 2) Correlate requests and logs
 	r.Use(middleware.RequestID())
 
-	// 3) Structured logging with redaction
-	r.Use(middleware.RedactingLogger(middleware.RedactOptions{
-		MaskHeaders: []string{
-			"X-API-Key", // project-specific sensitive header example
-		},
-	}))
+        // 3) Structured logging with redaction
+        r.Use(middleware.RedactingLogger(middleware.RedactOptions{
+                MaskHeaders: cfg.RedactHeaders,
+        }))
 
-	// 4) Panic recovery to JSON 500 (with request id)
-	r.Use(middleware.Recovery())
+        // 4) Development user stub (no-op when upstream auth already set a user)
+        r.Use(middleware.DemoUser())
 
-	// 5) Global body size limit (1 MiB)
-	r.Use(limitBody(1 << 20))
+        // 5) Panic recovery to JSON 500 (with request id)
+        r.Use(middleware.Recovery())
 
-	// 6) Prometheus metrics and /metrics endpoint
-	r.Use(middleware.Metrics())
-	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
+        // 6) Global body size limit (1 MiB)
+        r.Use(limitBody(1 << 20))
 
-	// 7) Idempotency validation (before rate limiting)
-	r.Use(middleware.IdempotencyValidator(
-		middleware.IdempotencyOptions{
-			MaxLen: 200,
-		},
-		func(ctx context.Context, userID, chatID, key string, now time.Time) (bool, error) {
-			rec, err := repo.GetIdempotency(ctx, db, userID, chatID, key, now)
-			if err != nil || rec == nil {
-				return false, nil
-			}
-			return true, nil
-		},
-	))
+        // 7) Prometheus metrics and /metrics endpoint
+        r.Use(middleware.Metrics())
+        r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
-	// 8) Token-bucket rate limiter per user/IP
-	rl := middleware.NewRateLimiter(cfg.RateRPS, cfg.RateBurst, middleware.KeyByUserOrIP())
-	r.Use(rl.Handler())
+        idemSvc := services.NewIdempotencyService(db, cfg.IdempotencyTTL)
 
-	// 9) CORS posture (safe defaults: allow all if none configured)
+        // 8) Idempotency validation (before rate limiting)
+        r.Use(middleware.IdempotencyValidator(
+                middleware.IdempotencyOptions{
+                        MaxLen: 200,
+                },
+                idemSvc.Exists,
+        ))
+
+        // 9) Token-bucket rate limiter per user/IP
+        rl := middleware.NewRateLimiter(cfg.RateRPS, cfg.RateBurst, middleware.KeyByUserOrIP())
+        r.Use(rl.Handler())
+
+        // 10) CORS posture (safe defaults: allow all if none configured)
 	if len(cfg.CORS.AllowedOrigins) == 0 {
 		// Force ACAO: * even for requests without an Origin header (helps tests and simple health checks).
 		r.Use(func(c *gin.Context) {
@@ -185,19 +182,19 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, idx search.Index, cfg config.Con
 	r.GET("/health", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"status": "ok"}) })
 
 	// Dependency injection: services ← repo/db/index
-	chatSvc := services.NewChatService(db, chatRepoShim{})
-	msgSvc := &services.MessageService{
-		DB:             db,
-		Index:          idx,
-		Threshold:      cfg.Threshold,
-		MaxPromptRunes: 2000,
-		MaxReplyRunes:  1500,
-		TitleMaxLen:    6,
-		TitleLocale:    language.English,
-	}
+        chatSvc := services.NewChatService(db, chatRepoShim{})
+        msgSvc := &services.MessageService{
+                DB:             db,
+                Index:          idx,
+                Threshold:      cfg.Threshold,
+                MaxPromptRunes: 2000,
+                MaxReplyRunes:  1500,
+                TitleMaxLen:    6,
+                TitleLocale:    language.English,
+        }
 
-	fbSvc := &services.FeedbackService{DB: db}
-	h := handlers.New(chatSvc, msgSvc, fbSvc)
+        fbSvc := &services.FeedbackService{DB: db}
+        h := handlers.New(chatSvc, msgSvc, fbSvc, idemSvc)
 
 	// Public API
 	apiBase := cfg.APIBasePath // e.g. "/api/v1"
@@ -206,7 +203,7 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, idx search.Index, cfg config.Con
 		// Chats
 		api.POST("/chats", h.CreateChat)
 		api.GET("/chats", h.ListChats)
-		api.PUT("/chats/:id/title", h.UpdateChatTitle)
+                api.PATCH("/chats/:id", h.UpdateChatTitle)
 
 		// Messages
 		api.GET("/chats/:id/messages", h.ListMessages)

--- a/internal/repo/db.go
+++ b/internal/repo/db.go
@@ -28,8 +28,10 @@ func OpenSQLite(path string) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	// PRAGMAs
-	db.Exec("PRAGMA journal_mode=WAL;")
+        // PRAGMAs
+        // WAL improves concurrent read performance for our API workload while
+        // still allowing the single-writer pattern SQLite enforces.
+        db.Exec("PRAGMA journal_mode=WAL;")
 	db.Exec("PRAGMA synchronous=NORMAL;")
 	db.Exec("PRAGMA foreign_keys=ON;")
 	db.Exec("PRAGMA busy_timeout=5000;")

--- a/internal/services/idempotency_service.go
+++ b/internal/services/idempotency_service.go
@@ -1,0 +1,78 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/tbourn/go-chat-backend/internal/domain"
+	"github.com/tbourn/go-chat-backend/internal/repo"
+)
+
+// IdempotencyService persists and retrieves idempotent request results.
+type IdempotencyService struct {
+	DB  *gorm.DB
+	TTL time.Duration
+}
+
+// NewIdempotencyService constructs an IdempotencyService with a fallback TTL.
+func NewIdempotencyService(db *gorm.DB, ttl time.Duration) *IdempotencyService {
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+	return &IdempotencyService{DB: db, TTL: ttl}
+}
+
+// Exists reports whether a non-expired idempotency record is stored.
+func (s *IdempotencyService) Exists(ctx context.Context, userID, chatID, key string, now time.Time) (bool, error) {
+	if s == nil || s.DB == nil {
+		return false, nil
+	}
+	rec, err := repo.GetIdempotency(ctx, s.DB, userID, chatID, key, now)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return rec != nil, nil
+}
+
+// Replay returns the previously stored message for (user, chat, key) when one exists.
+func (s *IdempotencyService) Replay(ctx context.Context, userID, chatID, key string, now time.Time) (*domain.Message, bool, error) {
+	if s == nil || s.DB == nil {
+		return nil, false, nil
+	}
+	rec, err := repo.GetIdempotency(ctx, s.DB, userID, chatID, key, now)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	msg, err := repo.GetMessage(s.DB, rec.MessageID)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return msg, true, nil
+}
+
+// Record stores the association between an idempotency key and a response message.
+func (s *IdempotencyService) Record(ctx context.Context, userID, chatID, key string, messageID string, status int) error {
+	if s == nil || s.DB == nil {
+		return nil
+	}
+	_, err := repo.CreateIdempotency(ctx, s.DB, userID, chatID, key, messageID, status, s.TTL)
+	if err != nil {
+		if errors.Is(err, repo.ErrDuplicate) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- move demo user stub into reusable middleware and add context utilities for user and pagination handling
- introduce an idempotency service to keep handlers transport-thin and wire it through the router alongside the new ctx helpers
- tweak REST surface (PATCH /chats/{id}), logging redaction config, Docker defaults, and document SQLite/WAL and security choices

## Testing
- go test ./... *(fails: go mod tidy requires downloading test-only dependencies; network access to proxy.golang.org is blocked in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8350df80832bb3d89957b76a6d96)